### PR TITLE
fix: updated peer dependency for class-validator

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@nestjs/common": "^7.0.0 || ^8.0.0 || ^9.0.0",
     "@nestjs/core": "^7.0.0 || ^8.0.0 || ^9.0.0",
     "class-transformer": "^0.4.0 || ^0.5.1",
-    "class-validator": "^0.13.1",
+    "class-validator": "^0.14.0",
     "reflect-metadata": "^0.1.13",
     "rxjs": "^6.6.3 || ^7.2.0 || ^7.5.0"
   },


### PR DESCRIPTION
It seems that I forgot to update the peer dependency on `class-validator` as well. Would you mind reviewing this?