### PR TITLE
refactor: the use of throwError(err) is deprecated

### DIFF
--- a/src/interceptors/FormData.interceptor.ts
+++ b/src/interceptors/FormData.interceptor.ts
@@ -59,7 +59,7 @@ export class FormDataInterceptor implements NestInterceptor {
 
       catchError((err) => {
         if (config.cleanupAfterFailedHandle || config.autoDeleteFile) formReader.deleteFiles();
-        return throwError(err);
+        return throwError(() => err);
       }),
 
       tap(() => {


### PR DESCRIPTION
This PR will fix the deprecated warning message: The signature `(error: any): Observable` of `throwError` is deprecated.

<img width="1294" alt="Screenshot 2024-09-07 at 19 59 32" src="https://github.com/user-attachments/assets/61aa91fa-96b4-42a7-8407-3848e242f5bd">
